### PR TITLE
fix(quality): resolve GitHub Copilot issues #56 and #57

### DIFF
--- a/.claude/skills/bmad-planner/scripts/create_planning.py
+++ b/.claude/skills/bmad-planner/scripts/create_planning.py
@@ -868,6 +868,8 @@ def commit_planning_docs(planning_dir: Path, slug: str) -> None:
     run_command(['git', 'add', str(planning_dir)], capture=False)
 
     # Create commit message
+    # Convert slug to human-readable title for commit message
+    # e.g., "protect-main-develop" → "Protect Main Develop"
     title = slug.replace('-', ' ').replace('_', ' ').title()
     commit_msg = f"""docs(planning): add BMAD planning for {title}
 

--- a/.claude/skills/git-workflow-manager/scripts/create_worktree.py
+++ b/.claude/skills/git-workflow-manager/scripts/create_worktree.py
@@ -185,6 +185,8 @@ Created: {created_timestamp}
             subprocess.run(['git', 'branch', '-D', branch_name],
                          stderr=subprocess.DEVNULL, check=False)
         except (subprocess.CalledProcessError, FileNotFoundError):
+            # Ignore errors during cleanup: worktree/branch may not exist or removal may fail,
+            # but the original error is more important and will be re-raised.
             pass
         raise
 


### PR DESCRIPTION
## Summary

This PR resolves 2 additional GitHub Copilot code review issues identified after PR #55 was merged.

### Changes

**Issue #57: Empty except clause without explanatory comment**
- **File:** `.claude/skills/git-workflow-manager/scripts/create_worktree.py:187-188`
- **Fix:** Added explanatory comment to except/pass block
- **Explanation:** Cleanup errors during exception handling are intentionally ignored because the original error is more important and will be re-raised
- **Ref:** https://github.com/stharrold/german/pull/55#discussion_r2490107212

**Issue #56: Clarify title variable usage**
- **File:** `.claude/skills/bmad-planner/scripts/create_planning.py:871-874`  
- **Fix:** Added comment explaining slug → title transformation
- **Clarifies:** Converting "protect-main-develop" → "Protect Main Develop" for human-readable commit messages is intentional behavior
- **Example:** Improves commit message readability while maintaining consistency
- **Ref:** https://github.com/stharrold/german/pull/55#discussion_r2490107143

### Quality Metrics

- **Tests:** 127 total (112 passed, 15 skipped) ✅
- **Coverage:** 88.1% (maintained) ✅
- **Linting:** All pyflakes (F-series) checks pass ✅
- **Type Checking:** Clean ✅

### Files Changed

**2 files with documentation improvements:**
- `.claude/skills/git-workflow-manager/scripts/create_worktree.py` (+2 lines comment)
- `.claude/skills/bmad-planner/scripts/create_planning.py` (+2 lines comment)

### Testing

All fixes verified with:
```bash
uv run pytest -v                # All 127 tests passing
uv run ruff check . --select F  # No pyflakes errors
```

### Related Issues

Closes #56
Closes #57

### Commit History

- `c18ea60` fix(quality): resolve GitHub Copilot issues #56 and #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)