### PR TITLE
fix(vcs): prevent print statement from executing during import (#50)

### DIFF
--- a/.claude/skills/workflow-utilities/scripts/vcs/config.py
+++ b/.claude/skills/workflow-utilities/scripts/vcs/config.py
@@ -17,8 +17,7 @@ from typing import Any, Dict, Optional
 try:
     import yaml
 except ImportError:
-    print("Error: PyYAML required. Install: pip install pyyaml", file=sys.stderr)
-    sys.exit(1)
+    yaml = None  # Will be checked in functions that use it
 
 
 # Constants
@@ -35,6 +34,9 @@ def load_vcs_config(config_path: Optional[Path] = None) -> Optional[Dict[str, An
     Returns:
         Configuration dict or None if file doesn't exist
 
+    Raises:
+        ImportError: If PyYAML is not installed
+
     Example config:
         vcs_provider: azure_devops
 
@@ -42,6 +44,12 @@ def load_vcs_config(config_path: Optional[Path] = None) -> Optional[Dict[str, An
           organization: "https://dev.azure.com/myorg"
           project: "MyProject"
     """
+    if yaml is None:
+        raise ImportError(
+            "PyYAML is required to load VCS configuration. "
+            "Install it with: pip install pyyaml"
+        )
+
     if config_path is None:
         config_path = Path.cwd() / CONFIG_FILE_NAME
 


### PR DESCRIPTION
## Summary
Fix issue #50 - prevent print statement from executing during module import.

## Problem
The VCS config module had a print statement and sys.exit(1) at module level
that would execute during import if PyYAML was missing. This violates Python
best practices and causes issues when the module is imported.

## Solution
- Move error handling from module level to function level
- Set `yaml = None` if ImportError during import
- Check for yaml availability in `load_vcs_config()` function
- Raise ImportError with helpful message only when yaml is actually needed

## Changes
- Modified: `.claude/skills/workflow-utilities/scripts/vcs/config.py`
  - Lines 17-21: Changed from print/exit to yaml = None
  - Lines 47-51: Added yaml availability check in function
  - Lines 38: Updated docstring to document ImportError

## Benefits
- Module can be imported safely even if PyYAML not installed
- Error only raised when VCS config loading is actually attempted
- Follows Python best practices (defer errors until usage)
- Enables graceful error handling by calling code

## Quality
- ✓ All tests passing (114 passed, 15 skipped)
- ✓ Test coverage: 88% (above required 80%)
- ✓ Linting: Clean
- ✓ VCS config tests: 16/16 passing

## Semantic Version
- **Type:** PATCH (bug fix)
- **Version:** v1.6.2

Closes #50

🤖 Generated with Claude Code