### PR TITLE
fix(git-workflow): address GitHub Copilot code review feedback (PR #139)

### DIFF
--- a/.claude/skills/git-workflow-manager/CHANGELOG.md
+++ b/.claude/skills/git-workflow-manager/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Uses `--force-with-lease` for safe force push after rebase
 
 ### Changed
-- **backmerge_release.py** - Now rebases before creating PR (Step 2 added to workflow)
-  - Updated main() workflow: validate → rebase → create PR
+- **backmerge_release.py** - Now rebases before creating PR (Step 3 added to workflow)
+  - Updated main() workflow: validate → check clean → rebase → create PR
   - Updated docstring with rebase requirements and rationale
   - Updated WORKFLOW.md to document pre-PR rebase pattern
 


### PR DESCRIPTION
## Summary

Addresses 3 of 4 GitHub Copilot code review comments from PR #139.

### Fixes Implemented

**Issue #140 - Error output detection**
- **Problem:** Only checking `stderr` for conflict detection, but git rebase may output to `stdout`
- **Solution:** Check both `stderr` and `stdout` for conflict indicators
- **Change:** `error_output = stderr + '\n' + stdout if both exist else (stderr or stdout)`
- **Impact:** More reliable conflict detection

**Issue #141 - Operation detection fallback**
- **Problem:** Defaulting to "push" for unknown operations could be misleading
- **Solution:** Explicit if/elif/else with meaningful fallback
- **Change:** Unknown operations show `"git command (cmd[0])"`  instead of defaulting to "push"
- **Impact:** Clearer error messages for unexpected failures

**Issue #143 - CHANGELOG step number**
- **Problem:** CHANGELOG said "Step 2" but rebase is actually Step 3 (after validation and clean check)
- **Solution:** Updated to "Step 3" and clarified workflow
- **Change:** `validate → check clean → rebase → create PR`
- **Impact:** Accurate documentation

### Skipped

**Issue #142 - Markdown formatting (nitpick)**
- **Status:** Current formatting is correct and consistent
- **Reasoning:** GitHub Copilot's suggestion is a minor style nitpick with no functional impact
- **Action:** None needed

### Testing

- ✅ All tests passing (114 passed, 15 skipped)
- ✅ Quality gates met
- ✅ No regressions

### Review Instructions

1. **Review error handling improvements** - Check backmerge_release.py changes
2. **Review CHANGELOG accuracy** - Verify step numbering
3. **Wait for CI** - Ensure all tests pass
4. **Merge** - Use GitHub merge button

---
*Part of PR #139 feedback workflow*

Closes #140
Closes #141
Closes #143

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>