### PR TITLE
docs(architecture): remove outdated line 77 reference

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -366,7 +366,7 @@ feature/20251108T143000Z_auth-system
 **Note:** This is algorithmic pseudo-code showing the orchestrator's decision logic, not executable Python. The orchestrator SKILL.md contains algorithms for skill selection, not executable code.
 
 ```
-# Algorithmic pseudo-code (not executable Python - see line 77)
+# Algorithmic pseudo-code (not executable Python)
 
 if not SESSION_CONFIG:
     load('tech-stack-adapter')      # Detect uv/Podman/Python version


### PR DESCRIPTION
## Summary

Removes outdated line reference from ARCHITECTURE.md pseudo-code comment.

### Issue

The pseudo-code comment at line 369 referenced "see line 77", but:
- This section is actually at line 369, not line 77
- Line 366 already clarifies this is algorithmic pseudo-code
- The reference is outdated and confusing

### Changes

**ARCHITECTURE.md:369**
- Removed outdated "see line 77" reference from comment
- Kept clarification that it's not executable Python

### Quality Gates

✅ Documentation-only change
✅ No code changes
✅ No tests affected

### Semantic Version

**v1.9.1** (PATCH - documentation fix)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)