### PR TITLE
refactor(git-workflow): improve error output readability

### DIFF
--- a/.claude/skills/git-workflow-manager/scripts/backmerge_release.py
+++ b/.claude/skills/git-workflow-manager/scripts/backmerge_release.py
@@ -201,7 +201,11 @@ def rebase_release_branch(release_branch, target_branch):
                 check=False
             )
             # Check both stderr and stdout to distinguish conflict from other failures (Issue #140, #146)
-            error_output = (result.stderr or '') + ('\n' if result.stderr and result.stdout else '') + (result.stdout or '')
+            # Extract error parts with intermediate variables for clarity (Issue #152)
+            stderr_part = result.stderr or ''
+            stdout_part = result.stdout or ''
+            separator = '\n' if stderr_part and stdout_part else ''
+            error_output = stderr_part + separator + stdout_part
             if 'CONFLICT' in error_output or 'conflict' in error_output.lower():
                 error_type = "Rebase conflict"
             else:


### PR DESCRIPTION
## Summary

Refactor conditional newline logic in backmerge_release.py for better readability and maintainability.

### Issue

The conditional newline insertion logic was compact but difficult to read:
```python
error_output = (result.stderr or '') + ('\n' if result.stderr and result.stdout else '') + (result.stdout or '')
```

### Changes

**backmerge_release.py:204**
- Extracted stderr_part, stdout_part, separator into intermediate variables
- Same logic, improved clarity
- Easier to understand and debug

**Before:**
```python
error_output = (result.stderr or '') + ('\n' if result.stderr and result.stdout else '') + (result.stdout or '')
```

**After:**
```python
stderr_part = result.stderr or ''
stdout_part = result.stdout or ''
separator = '\n' if stderr_part and stdout_part else ''
error_output = stderr_part + separator + stdout_part
```

### Quality Gates

✅ All tests passing (114 passed, 15 skipped)
✅ No functional changes
✅ Code readability improved

### Semantic Version

**v5.2.2** (PATCH - code readability improvement, no behavior change)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)