### PR TITLE
chore(release): back-merge v1.10.0 to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,6 +371,8 @@ Earlier versions (< 5.0.0) used a different workflow architecture. See `ARCHIVED
 
 | Version | Date       | Type  | Description |
 |---------|------------|-------|-------------|
+| 1.10.0  | 2025-11-16 | MINOR | MIT Agent Synchronization Pattern (Phase 1) + DuckDB compatibility fixes |
+| 1.9.0   | 2025-11-09 | MINOR | Work-item generation workflow + VCS adapter enhancements |
 | 1.8.2   | 2025-11-07 | PATCH | Bug fixes for code quality issues + simplified backmerge workflow |
 | 1.8.1   | 2025-11-07 | PATCH | Branch protection compliance + Azure DevOps documentation |
 | 1.8.0   | 2025-11-07 | MINOR | CI/CD replication guide + DRY navigation improvements |


### PR DESCRIPTION
## Back-merge Release to Develop

This PR merges `release/v1.10.0` back to `develop` to complete the release cycle.

### Release Information
- **Version:** v1.10.0
- **Release Tag:** https://github.com/stharrold/german/releases/tag/v1.10.0
- **Source Branch:** `release/v1.10.0`
- **Target Branch:** `develop`

### What This PR Does

Merges release-specific changes (documentation, version bumps) from the release branch back to develop, ensuring develop stays in sync with production releases.

### Review Instructions

1. **Review changes** - Verify documentation updates and version changes
2. **Wait for CI** - Ensure all tests pass
3. **Merge** - Use GitHub/Azure DevOps portal merge button when ready (no approval required)

GitHub will automatically detect any merge conflicts. If conflicts exist, resolve them in the PR.

This follows the git-flow release workflow where all merges to develop go through PRs, even for release back-merges.

### Next Steps After Merge

Run cleanup script:
```bash
python .claude/skills/git-workflow-manager/scripts/cleanup_release.py v1.10.0
```

---
*Generated by backmerge_release.py*
