### PR TITLE
Release v1.10.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,19 +63,12 @@ cat TODO.md  # See active workflows
   - HIPAA/FDA/IRB-compliant audit trail design
   - Test suite with 557 test cases (test_schema_migration.py, 706 lines)
   - PRs #165, #173, #179 merged to main
-  - Issues #174, #175, #177, #180, #181, #187 resolved
-- **Phases 2-6: Ready for implementation (Issues #160-#164)**
-  - Phase 2 (Issue #160): Synchronization Engine
-  - Phase 3 (Issue #161): Integration Layer
-  - Phase 4 (Issue #162): Default Synchronization Rules
-  - Phase 5 (Issue #163): Testing and Healthcare Compliance Validation
-  - Phase 6 (Issue #164): Performance Validation and Documentation
+  - All phase-1-schema issues resolved (including #167-172 closed in v1.10.1)
+  - Post-release cleanup completed in v1.10.1
 
-**Check active issues:** `gh issue list --state open --label MIT-sync-pattern`
+**No active development initiatives at this time.**
 
-**Current parallelization opportunities:**
-- Stage 2: Issues #160 + #161 can run in parallel (35-47% time savings)
-- Stage 4: Issues #163 + #164 can run in parallel (after Stage 2-3 complete)
+Check for new work: `gh issue list --state open`
 
 ## Workflow Execution Flow
 
@@ -1199,9 +1192,10 @@ Automatic version calculation based on changes:
 - **MINOR**: New features (new files, new endpoints)
 - **PATCH**: Bug fixes, refactoring, docs, tests
 
-**Current version:** v1.10.0 (latest stable)
+**Current version:** v1.10.1 (latest stable)
 
 **Recent releases:**
+- v1.10.1: Post-v1.10.0 documentation cleanup and issue resolution (PATCH)
 - v1.10.0: MIT Agent Synchronization Pattern (Phase 1) + DuckDB compatibility fixes (MINOR)
 - v1.9.1: ARCHITECTURE.md documentation clarity improvements (PATCH)
 - v1.9.0: PR feedback work-item generation workflow (MINOR)
@@ -1214,6 +1208,13 @@ Automatic version calculation based on changes:
 - v1.4.0: BMAD and SpecKit callable tools with token reduction (MINOR)
 - v1.3.0: Complete B1 German listening practice library (MINOR)
 - v1.2.0: Release automation scripts + workflow v5.0 architecture (MINOR)
+
+**Included in v1.10.1:**
+- Post-release documentation cleanup (ARCHIVED directories, compliance docs)
+- Closed duplicate issues from Phase 1 (#167-172)
+- APPEND-ONLY terminology standardization
+- YAML frontmatter spacing fixes
+- Updated CLAUDE.md for v1.10.0 completion status
 
 **Included in v1.10.0:**
 - MIT Agent Synchronization Pattern Phase 1 (database schema, HIPAA/FDA/IRB compliance)

--- a/benchmarks/ARCHIVED/CLAUDE.md
+++ b/benchmarks/ARCHIVED/CLAUDE.md
@@ -28,8 +28,8 @@ Expected file pattern: `YYYYMMDD_HHMMSS_description.zip`
 ## Usage
 
 When working with archived benchmarks:
-1. Use `archive_manager.py list` to view available archives
-2. Use `archive_manager.py extract` to restore archived files for reference
+1. Use `archive_manager.py list benchmarks/ARCHIVED` to view available archives
+2. Use `archive_manager.py extract benchmarks/ARCHIVED/<archive>.zip <output_dir>` to restore archived files for reference
 3. Never modify archived files directly - they are read-only historical records
 4. To deprecate new files, use `deprecate_files.py` from workflow-utilities
 

--- a/benchmarks/ARCHIVED/README.md
+++ b/benchmarks/ARCHIVED/README.md
@@ -29,12 +29,12 @@ Each archive includes a manifest describing the archived content and reason for 
 To extract archived files:
 ```bash
 python .claude/skills/workflow-utilities/scripts/archive_manager.py \
-  extract ARCHIVED/<archive>.zip restored/
+  extract benchmarks/ARCHIVED/<archive>.zip restored/
 ```
 
 To list all archives:
 ```bash
-python .claude/skills/workflow-utilities/scripts/archive_manager.py list
+python .claude/skills/workflow-utilities/scripts/archive_manager.py list benchmarks/ARCHIVED
 ```
 
 ## Related Documentation

--- a/docs/ARCHIVED/CLAUDE.md
+++ b/docs/ARCHIVED/CLAUDE.md
@@ -28,8 +28,8 @@ Expected file pattern: `YYYYMMDD_HHMMSS_description.zip`
 ## Usage
 
 When working with archived documentation:
-1. Use `archive_manager.py list` to view available archives
-2. Use `archive_manager.py extract` to restore archived files for reference
+1. Use `archive_manager.py list docs/ARCHIVED` to view available archives
+2. Use `archive_manager.py extract docs/ARCHIVED/<archive>.zip <output_dir>` to restore archived files for reference
 3. Never modify archived files directly - they are read-only historical records
 4. To deprecate new files, use `deprecate_files.py` from workflow-utilities
 

--- a/docs/ARCHIVED/README.md
+++ b/docs/ARCHIVED/README.md
@@ -29,12 +29,12 @@ Each archive includes a manifest describing the archived content and reason for 
 To extract archived files:
 ```bash
 python .claude/skills/workflow-utilities/scripts/archive_manager.py \
-  extract ARCHIVED/<archive>.zip restored/
+  extract docs/ARCHIVED/<archive>.zip restored/
 ```
 
 To list all archives:
 ```bash
-python .claude/skills/workflow-utilities/scripts/archive_manager.py list
+python .claude/skills/workflow-utilities/scripts/archive_manager.py list docs/ARCHIVED
 ```
 
 ## Related Documentation


### PR DESCRIPTION
## Release v1.10.2

Documentation improvements and archive path corrections following v1.10.1.

## Changes Summary

### CLAUDE.md Updates
- Updated current version from v1.10.0 to v1.10.1
- Marked all MIT Agent Synchronization Pattern work as complete
- Removed outdated Phases 2-6 references (work was never initiated)
- Added v1.10.1 to recent releases and features list
- Simplified Current Active Work section to "No active development initiatives"

### Archive Path Fixes
- Fixed incorrect archive paths in 4 ARCHIVED directory documentation files
- Updated docs/ARCHIVED/README.md to use `docs/ARCHIVED/` path
- Updated docs/ARCHIVED/CLAUDE.md to use `docs/ARCHIVED/` path
- Updated benchmarks/ARCHIVED/README.md to use `benchmarks/ARCHIVED/` path
- Updated benchmarks/ARCHIVED/CLAUDE.md to use `benchmarks/ARCHIVED/` path

Previously, archive_manager.py examples incorrectly referenced repo root `ARCHIVED/`
instead of subdirectory-specific paths like `docs/ARCHIVED/` or `benchmarks/ARCHIVED/`.

## Files Changed
- 5 files changed (+21/-20 lines)

## Issues Resolved
- Issue #191: Archive paths in docs/ARCHIVED/README.md
- Issue #192: Archive paths in docs/ARCHIVED/CLAUDE.md
- Issue #193: Archive paths in benchmarks/ARCHIVED/README.md
- Issue #194: Archive paths in benchmarks/ARCHIVED/CLAUDE.md

## Type
- Documentation improvements (PATCH release)

## Version
v1.10.1 → v1.10.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)