### PR TITLE
chore(release): back-merge v1.11.0 to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Planned
-- None currently planned
+- Phase 3: Integration Layer Implementation (Issue #161)
+- Phase 4: Default Synchronization Rules (Issue #162)
+- Phase 5: Comprehensive Testing and Healthcare Compliance Validation (Issue #163)
+- Phase 6: Performance Validation and Documentation (Issue #164)
+
+## [1.11.0] - 2025-11-17
+
+### Added
+- **MIT Agent Synchronization Pattern (Phase 2: Synchronization Engine)** - Core bidirectional sync engine
+  - Comprehensive synchronization engine (sync_engine.py, 559 lines)
+  - Declarative synchronization coordination with pattern matching
+  - Idempotency enforcement via SHA-256 content-addressed hashing
+  - Conflict detection and resolution strategies
+  - HIPAA-compliant audit trail tracking with APPEND-ONLY enforcement
+  - Performance optimizations: <100ms p95 latency target, <1ms p99 hash computation
+  - Test suite with 22 comprehensive tests (test_sync_engine.py, 689 lines)
+  - Phase 2 integration guide (phase2_integration_guide.md, 394 lines)
+  - Database migration for Phase 2 tables (phase2_migration.sql, 215 lines)
+  - Workflow tracking documentation (TODO_feature_20251117T024349Z_phase-2-engine.md, 1,720 lines)
+  - Python package structure for .claude/ directory (__init__.py files)
+
+### Changed
+- **Linting configuration** - N999 exception for .claude directory
+  - Added per-file-ignores in pyproject.toml to allow __init__.py files in .claude/
+  - Acknowledges .claude/ as special configuration directory (similar to .github/, .vscode/)
+  - Preserves Python package structure while maintaining PEP 8 compliance
+
+### Fixed
+- **Code quality improvements** - Resolved GitHub Copilot review items
+  - Issue #199: Removed unsupported array access claim from _resolve_params docstring
+  - Issue #200: Removed unused Path import from sync_engine.py
+  - Issue #201: Removed unused uuid4 import from test_sync_engine.py
+  - Issue #203: Fixed N999 linting errors for .claude directory
+  - Auto-fixed import sorting per ruff recommendations
+
+### Dependencies
+- No new dependencies (continues to use duckdb>=1.4.2 from Phase 1)
 
 ## [1.10.0] - 2025-11-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "german"
-version = "1.8.3"
+version = "1.11.0"
 description = "German language learning resources and tools"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Back-merge Release to Develop

This PR merges `release/v1.11.0` back to `develop` to complete the release cycle.

### Release Information
- **Version:** v1.11.0
- **Release Tag:** https://github.com/stharrold/german/releases/tag/v1.11.0
- **Source Branch:** `release/v1.11.0`
- **Target Branch:** `develop`

### What This PR Does

Merges release-specific changes (documentation, version bumps) from the release branch back to develop, ensuring develop stays in sync with production releases.

### Review Instructions

1. **Review changes** - Verify documentation updates and version changes
2. **Wait for CI** - Ensure all tests pass
3. **Merge** - Use GitHub/Azure DevOps portal merge button when ready (no approval required)

GitHub will automatically detect any merge conflicts. If conflicts exist, resolve them in the PR.

This follows the git-flow release workflow where all merges to develop go through PRs, even for release back-merges.

### Next Steps After Merge

Run cleanup script:
```bash
python .claude/skills/git-workflow-manager/scripts/cleanup_release.py v1.11.0
```

---
*Generated by backmerge_release.py*
