### PR TITLE
fix: batch 4 code cleanup (issue #222)

### DIFF
--- a/.claude/skills/agentdb-state-manager/scripts/worktree_agent_integration.py
+++ b/.claude/skills/agentdb-state-manager/scripts/worktree_agent_integration.py
@@ -31,21 +31,11 @@ import os
 import re
 import subprocess
 import sys
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
-
-
-class FlowTokenType(Enum):
-    """Types of flow tokens for different workflow contexts."""
-
-    MAIN_REPO = "main_repo"
-    WORKTREE = "worktree"
-    ISSUE = "issue"
-    AD_HOC = "ad_hoc"
 
 
 class FlowTokenManager:


### PR DESCRIPTION
## Summary

This PR fixes issue #222 from the Phase 3 linting review.

**Note:** Issues #218-221 were already fixed in commit 7f7d9d2 but the issues remained open because they need to be manually closed. This PR addresses the one remaining unfixed issue (#222) and will trigger manual closure of all 5 issues.

## Changes

**Issue #222 - Remove unused FlowTokenType enum:**
- Removed `FlowTokenType` enum class (lines 42-48)
- Removed unused `from enum import Enum` import (line 34)
- File: `.claude/skills/agentdb-state-manager/scripts/worktree_agent_integration.py`

## Already Fixed in Commit 7f7d9d2

The following issues were fixed in commit 7f7d9d2 but didn't auto-close:

**Issue #218 - Remove unused imports in tests:**
- Removed `asyncio`, `json`, `os` imports from `tests/skills/test_worktree_integration.py`

**Issue #219 - Remove unused imports in integration layer:**
- Removed `asyncio`, `hashlib`, `json` imports from `worktree_agent_integration.py`

**Issue #220 - Remove unused variables in tests:**
- Removed `tmp_dir`, `original_get_flow_token`, `mock_engine` variables
- Changed `engine = SyncEngineFactory.create_sync_engine()` to direct call

**Issue #221 - Remove unused exception variable:**
- Changed `except Exception as e:` to `except Exception:` in `create_planning.py`

## Test Results

**Linting:** ✓ All checks passed
**Tests:** ✓ 40 passed, 4 skipped
**Coverage:** ✓ 88.0% (≥80% required)
**Build:** ✓ Successful
**Type Checking:** ✓ Passed

## Related Issues

Fixes #222

Will manually close #218, #219, #220, #221 after merge (already fixed in 7f7d9d2)

🤖 Generated with Claude Code