### PR TITLE
docs(workflow): clarify Phase 3 vs Phase 4 version numbers (Issue #247)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,17 +88,18 @@ cat TODO.md  # See active workflows
   - v1.12.0 released and tagged
   - Linting fixes applied (Issues #218-#221 closed)
 
-- **Phase 4 (Issue #162): ✅ COMPLETED** (pending v1.13.0 release)
+- **Phase 4 (Issue #162): IN PROGRESS** (on contrib/stharrold, pending PR to develop)
   - Default synchronization rules implemented (default_synchronizations.sql, 456 lines)
   - 8 synchronization rules (4 normal flow + 4 error recovery)
-  - Comprehensive test suite (test_default_syncs.py, 389 lines, 12 tests)
-  - Design rationale documentation (phase4_default_rules_rationale.md, 700+ lines)
+  - Implementation complete on contrib/stharrold branch
+  - Design rationale documentation (phase4_default_rules_rationale.md)
   - 4-tier workflow coverage (Orchestrate → Develop → Assess → Research)
   - Priority-based rule execution (200 for errors > 100 for normal flow)
-  - PR #241 merged to contrib
-  - 7 follow-up issues created (Issues #242-248) for Phase 5+ enhancements
+  - 7 follow-up issues created (Issues #242-248) for refinements
+  - NOT YET MERGED to develop or released (will be v1.13.0 when released)
 
 **Next phases ready for implementation:**
+- Phase 4 (Issue #162): Default Synchronization Rules (PR review pending)
 - Phase 5 (Issue #163): Testing & Compliance (ready after Phase 4 merges)
 - Phase 6 (Issue #164): Performance & Docs (parallel-ok, blocked by Phase 5)
 


### PR DESCRIPTION
## Summary

- Clarify Phase 3 completed in v1.12.0 (released)
- Clarify Phase 4 is IN PROGRESS (not yet merged/released)
- Fix misleading "COMPLETED (pending v1.13.0 release)" status

## Changes

Updated CLAUDE.md to accurately reflect:
- Phase 3 (Issue #161): ✅ COMPLETED in v1.12.0
- Phase 4 (Issue #162): IN PROGRESS (on contrib/stharrold, pending PR to develop)
- Phase 4 will be v1.13.0 when released

## Context

Previous status incorrectly marked Phase 4 as "COMPLETED (pending v1.13.0 release)"
but the work exists only on contrib/stharrold and has not been merged to develop.

CHANGELOG.md correctly shows Phase 4 as "Planned" (unreleased).

## Test Plan

- [x] Verify git tags: v1.12.0 exists and is tagged
- [x] Verify CHANGELOG.md shows Phase 4 as "Planned"
- [x] Verify Phase 4 implementation exists on contrib/stharrold
- [x] Update CLAUDE.md with accurate status

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)