### PR TITLE
chore(release): back-merge v1.15.1 to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.1] - 2025-11-18
+
+### Changed
+- **CLAUDE.md improvements** - Enhanced onboarding and reduced duplication
+  - Added Quick Reference Card with 7 common workflows + 3 core commands
+  - Added Current Repository State section with pre-work checklist
+  - Added "What NOT to Do" section (9 prohibitions + 5 best practices)
+  - Consolidated version history: 109 lines → 23 lines (links to CHANGELOG.md for details)
+  - File size: 1,482 → 1,445 lines (-37 lines, -2.5%)
+
+- **WORKFLOW-INIT-PROMPT.md** - Clarified workflow application for existing repositories
+  - Separated "From This Repo" vs "From Downloaded Release" approaches
+  - Simplified prompt for Claude Code: "Read `/path/to/german`. Apply the workflow..."
+
+### Added
+- **.github/WORKTREE_CLEANUP_GUIDE.md** - Prevention strategies for worktree cleanup issues
+  - Comprehensive guide to atomic cleanup script usage
+  - Verification procedures and recovery steps
+
 ## [1.15.0] - 2025-11-18
 
 ### Added


### PR DESCRIPTION
## Back-merge Release to Develop

This PR merges `release/v1.15.1` back to `develop` to complete the release cycle.

### Release Information
- **Version:** v1.15.1
- **Release Tag:** https://github.com/stharrold/german/releases/tag/v1.15.1
- **Source Branch:** `release/v1.15.1`
- **Target Branch:** `develop`

### What This PR Does

Merges release-specific changes (documentation, version bumps) from the release branch back to develop, ensuring develop stays in sync with production releases.

### Review Instructions

1. **Review changes** - Verify documentation updates and version changes
2. **Wait for CI** - Ensure all tests pass
3. **Merge** - Use GitHub/Azure DevOps portal merge button when ready (no approval required)

GitHub will automatically detect any merge conflicts. If conflicts exist, resolve them in the PR.

This follows the git-flow release workflow where all merges to develop go through PRs, even for release back-merges.

### Next Steps After Merge

Run cleanup script:
```bash
python .claude/skills/git-workflow-manager/scripts/cleanup_release.py v1.15.1
```

---
*Generated by backmerge_release.py*
